### PR TITLE
refactor: update package.json overrides to use dynamic versioning

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,9 +45,9 @@
     "vite": "^5.3.5"
   },
   "overrides": {
-    "@types/react": "npm:types-react@rc",
-    "@types/react-dom": "npm:types-react-dom@rc",
-    "react": "19.0.0-rc-1460d67c-20241003",
-    "react-dom": "19.0.0-rc-1460d67c-20241003"
+    "@types/react": "$@types/react",
+    "@types/react-dom": "$@types/react-dom",
+    "react": "$react",
+    "react-dom": "$react-dom"
   }
 }


### PR DESCRIPTION
This PR updates the `overrides` section in `package.json` to use dynamic versioning for dependencies. 

This change follows the recommended usage of npm's "overrides" feature as described in the [npm documentation](https://docs.npmjs.com/cli/v8/configuring-npm/package-json#:~:text=To%20make%20this%20limitation%20easier%20to%20deal%20with%2C%20overrides%20may%20also%20be%20defined%20as%20a%20reference%20to%20a%20spec%20for%20a%20direct%20dependency%20by%20prefixing%20the%20name%20of%20the%20package%20you%20wish%20the%20version%20to%20match%20with%20a%20%24.). By using the `$` prefix, we're now referencing the versions specified in the direct dependencies, making our dependency management more flexible and maintainable.
