### PR TITLE
fix: removed autoprefixer and postcss

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,8 +39,6 @@
     "@types/react-dom": "npm:types-react-dom@rc",
     "@react-router/dev": "^7.0.0-pre.0",
     "@total-typescript/tsconfig": "^1.0.4",
-    "autoprefixer": "^10.4.19",
-    "postcss": "^8.4.40",
     "tailwindcss": "^4.0.0-alpha.26",
     "vite": "^5.3.5"
   },


### PR DESCRIPTION
I removed autoprefixer and postcss because both weren't used. The tailwind plugin does both via Lightning CSS.